### PR TITLE
feat(admin): implement password reset functionality

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -13,6 +13,7 @@ import AdminLogin from "./pages/admin/admin-login";
 import CategoryManagement from "./pages/admin/category-management";
 import Profile from "./pages/admin/Profile";
 import Notification from "./pages/admin/notification";
+import ResetPassword from "./pages/admin/resetPassword";
 
 import { Toaster } from "sonner";
 function App() {
@@ -39,6 +40,7 @@ function App() {
               <Route path="edit-article/:id" element={<EditArticle />} />
               <Route path="profile" element={<Profile />} />
               <Route path="notification" element={<Notification />} />
+              <Route path="reset-password" element={<ResetPassword />} />
             </Route>
             
             {/* Admin Login Route (outside of AdminLayout) */}

--- a/client/src/Components/ui/Sidebar.jsx
+++ b/client/src/Components/ui/Sidebar.jsx
@@ -46,7 +46,7 @@ export function Sidebar() {
     {
       id: "reset-password",
       name: "Reset password",
-      path: "/admin/dashboard/reset",
+      path: "/admin/reset-password",
       icon: TbRefresh,
     },
   ];
@@ -78,7 +78,7 @@ export function Sidebar() {
       {/* Logo Section */}
       <div className="p-6">
         <Link to="/" className="block">
-          <h1 className="text-2xl font-bold text-gray-800">hh.</h1>
+          <h1 className="text-2xl font-bold text-gray-800">Porsche</h1>
         </Link>
         <p className="text-sm text-orange-500 mt-1">Admin panel</p>
       </div>
@@ -132,7 +132,7 @@ export function Sidebar() {
               d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
             />
           </svg>
-          <span className="text-sm">hh. website</span>
+          <span className="text-sm">Porsche. website</span>
         </a>
 
         {/* Logout Button */}

--- a/client/src/pages/admin/resetPassword.jsx
+++ b/client/src/pages/admin/resetPassword.jsx
@@ -1,0 +1,222 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useCustomToast } from "../../Components/ui/CustomToast";
+import { useAuth } from "../../contexts/authentication";
+import axios from "axios";
+
+const ResetPassword = () => {
+  const navigate = useNavigate();
+  const toast = useCustomToast();
+  const { token } = useAuth();
+
+  const [formData, setFormData] = useState({
+    currentPassword: "",
+    newPassword: "",
+    confirmPassword: "",
+  });
+
+  const [loading, setLoading] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+
+  // Create axios instance
+  const api = axios.create({
+    baseURL: "http://localhost:5000/api",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async () => {
+    // Validation
+    if (!formData.currentPassword.trim()) {
+      toast.error("Please enter your current password");
+      return;
+    }
+
+    if (!formData.newPassword.trim()) {
+      toast.error("Please enter a new password");
+      return;
+    }
+
+    if (formData.newPassword.length < 6) {
+      toast.error("New password must be at least 6 characters");
+      return;
+    }
+
+    if (formData.newPassword !== formData.confirmPassword) {
+      toast.error("New passwords do not match");
+      return;
+    }
+
+    if (formData.currentPassword === formData.newPassword) {
+      toast.error("New password must be different from current password");
+      return;
+    }
+
+    setShowModal(true);
+  };
+
+  const confirmReset = async () => {
+    setLoading(true);
+    const loadingToast = toast.loading("Updating password...");
+
+    try {
+      const response = await api.put("/auth/reset-password", {
+        currentPassword: formData.currentPassword,
+        newPassword: formData.newPassword,
+      });
+
+      toast.dismiss(loadingToast);
+      toast.success("Password updated successfully!");
+      
+      // Clear form
+      setFormData({
+        currentPassword: "",
+        newPassword: "",
+        confirmPassword: "",
+      });
+      
+      setShowModal(false);
+    } catch (error) {
+      toast.dismiss(loadingToast);
+      console.error("Reset password error:", error);
+
+      if (error.response?.data?.error) {
+        toast.error(error.response.data.error);
+      } else {
+        toast.error("Failed to update password");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold text-gray-800 mb-8">Reset password</h1>
+
+      <div className="bg-white rounded-lg p-6 max-w-md">
+        {/* Current Password */}
+        <div className="mb-6">
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Current password
+          </label>
+          <input
+            type="password"
+            name="currentPassword"
+            value={formData.currentPassword}
+            onChange={handleChange}
+            placeholder="Current password"
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-gray-400 text-black"
+            required
+          />
+        </div>
+
+        {/* New Password */}
+        <div className="mb-6">
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            New password
+          </label>
+          <input
+            type="password"
+            name="newPassword"
+            value={formData.newPassword}
+            onChange={handleChange}
+            placeholder="New password"
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-gray-400 text-black"
+            required
+          />
+        </div>
+
+        {/* Confirm New Password */}
+        <div className="mb-6">
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Confirm new password
+          </label>
+          <input
+            type="password"
+            name="confirmPassword"
+            value={formData.confirmPassword}
+            onChange={handleChange}
+            placeholder="Confirm new password"
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-gray-400 text-black"
+            required
+          />
+        </div>
+
+        {/* Reset Button */}
+        <div className="flex justify-end">
+          <button
+            onClick={handleSubmit}
+            disabled={loading}
+            className="px-6 py-2 bg-gray-900 text-white rounded-full hover:bg-gray-800 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Reset password
+          </button>
+        </div>
+      </div>
+
+      {/* Confirmation Modal */}
+      {showModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-lg w-full max-w-sm p-6">
+            {/* Header */}
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-xl font-semibold">Reset password</h2>
+              <button
+                onClick={() => setShowModal(false)}
+                className="text-gray-400 hover:text-gray-600 cursor-pointer"
+              >
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            {/* Content */}
+            <div className="mb-6">
+              <p className="text-gray-600">
+                Do you want to reset your password?
+              </p>
+            </div>
+
+            {/* Footer */}
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setShowModal(false)}
+                disabled={loading}
+                className="px-6 py-2 border border-gray-300 rounded-full hover:bg-gray-50 transition-colors cursor-pointer disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmReset}
+                disabled={loading}
+                className="px-6 py-2 bg-gray-900 text-white rounded-full hover:bg-gray-800 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {loading ? "Resetting..." : "Reset"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ResetPassword;


### PR DESCRIPTION
This pull request introduces a "Reset Password" feature for the admin panel, including frontend and backend implementations. The most important changes involve adding a new `ResetPassword` page, updating the sidebar navigation, and implementing a secure API endpoint for password reset functionality.

### Frontend Changes:

* **New Reset Password Page:**
  - Added a new `ResetPassword` component in `client/src/pages/admin/resetPassword.jsx` with form validation, a confirmation modal, and API integration for password reset.
  - Imported the `ResetPassword` component into `client/src/App.jsx` and added a route for `/reset-password` under the admin layout. [[1]](diffhunk://#diff-51b002bf85fbd146b38871b89ba0d41c2bead37756295748c67206aac23ddc9aR16) [[2]](diffhunk://#diff-51b002bf85fbd146b38871b89ba0d41c2bead37756295748c67206aac23ddc9aR43)

* **Sidebar Updates:**
  - Updated the sidebar navigation to link to `/admin/reset-password` instead of `/admin/dashboard/reset`.
  - Changed the sidebar branding text from "hh." to "Porsche" for consistency. [[1]](diffhunk://#diff-62b98b965254f7ddb61f64966974430fa0aa775132af562789bebf152598900bL81-R81) [[2]](diffhunk://#diff-62b98b965254f7ddb61f64966974430fa0aa775132af562789bebf152598900bL135-R135)

### Backend Changes:

* **Reset Password API Endpoint:**
  - Added a new `PUT /reset-password` endpoint in `server/apps/auth.js` to handle password reset requests securely. This includes validation, password hashing, and database updates.